### PR TITLE
Update to GraalVM 20.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
    global:
     - CI=true
-    - GRAALVM_VERSION="20.1.0"
+    - GRAALVM_VERSION="20.2.0"
     - GRAALVM_JAVA_VERSION="11"
     - GRAALPHP_BUILD_NATIVE="true"
     - TEST="./graalphp-language/tests/assign/assign-var-03.php"
@@ -16,10 +16,10 @@ jdk:
   - openjdk11
 
 install:
-  - GRAAL_VM="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java11-linux-amd64-20.1.0.tar.gz"
+  - GRAAL_VM="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java11-linux-amd64-20.2.0.tar.gz"
   - curl -LJ $GRAAL_VM --output graalvm.tar.gz
   - tar -xzf graalvm.tar.gz
-  - JAVA_HOME=$(pwd)/graalvm-ce-java11-20.1.0
+  - JAVA_HOME=$(pwd)/graalvm-ce-java11-20.2.0
   - echo $JAVA_HOME
   - export JAVA_HOME
   - $JAVA_HOME/bin/gu install native-image

--- a/benchmarks/scripts-report/bench_spectralnorm.py
+++ b/benchmarks/scripts-report/bench_spectralnorm.py
@@ -83,7 +83,7 @@ class BenchmarkSpectralNorm(Bench):
         self.import_data(path,
                          test_name=TEST_BY_UNMOD,
                          prefix=pref,
-                         comment='intel turbo disabled, graal 20.1.0',
+                         comment='intel turbo disabled, graal 20.2.0',
                          binary='php',
                          )
 

--- a/docker/install-dev-env.sh
+++ b/docker/install-dev-env.sh
@@ -12,13 +12,13 @@ apt-get -y install php7.4 git
 echo "installing graalvm"
 apt-get -y install curl tar
 
-GRAAL_VM="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java11-linux-amd64-20.1.0.tar.gz"
+GRAAL_VM="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java11-linux-amd64-20.2.0.tar.gz"
  
 cd $build_dir
 curl -LJ $GRAAL_VM --output graalvm.tar.gz
 tar -xzf graalvm.tar.gz
 
-mv graalvm-ce-java11-20.1.0 graalvm
+mv graalvm-ce-java11-20.2.0 graalvm
 export JAVA_HOME=$(pwd)/graalvm
 $JAVA_HOME/bin/gu install native-image
 export PATH="$build_dir/graalvm/bin:${PATH}"

--- a/graalphp
+++ b/graalphp
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="20.1.0"
+VERSION="20.2.0"
 
 MAIN_CLASS="org.graalphp.launcher.GraalPhpMain"
 SCRIPT_HOME="$(cd "$(dirname "$0")" && pwd -P)"

--- a/graalphp-component/make_component.sh
+++ b/graalphp-component/make_component.sh
@@ -41,8 +41,8 @@ mkdir -p "$COMPONENT_DIR/META-INF"
 {
     echo "Bundle-Name: Graal PHP";
     echo "Bundle-Symbolic-Name: org.graalphp";
-    echo "Bundle-Version: 20.1.0";
-    echo 'Bundle-RequireCapability: org.graalvm; filter:="(&(graalvm_version=20.1.0)(os_arch=amd64))"';
+    echo "Bundle-Version: 20.2.0";
+    echo 'Bundle-RequireCapability: org.graalvm; filter:="(&(graalvm_version=20.2.0)(os_arch=amd64))"';
     echo "x-GraalVM-Polyglot-Part: True"
 } > "$COMPONENT_DIR/META-INF/MANIFEST.MF"
 

--- a/graalphp-component/pom.xml
+++ b/graalphp-component/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.graalphp</groupId>
         <artifactId>graalphp-parent</artifactId>
-        <version>20.1.0-SNAPSHOT</version>
+        <version>20.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>graalphp-component</artifactId>
     <properties>

--- a/graalphp-language/pom.xml
+++ b/graalphp-language/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.graalphp</groupId>
         <artifactId>graalphp-parent</artifactId>
-        <version>20.1.0-SNAPSHOT</version>
+        <version>20.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>graalphp-language</artifactId>
 

--- a/graalphp-launcher/pom.xml
+++ b/graalphp-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.graalphp</groupId>
         <artifactId>graalphp-parent</artifactId>
-        <version>20.1.0-SNAPSHOT</version>
+        <version>20.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>graalphp-launcher</artifactId>
     <build>

--- a/graalphp-native/pom.xml
+++ b/graalphp-native/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.graalphp</groupId>
         <artifactId>graalphp-parent</artifactId>
-        <version>20.1.0-SNAPSHOT</version>
+        <version>20.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>graalphp-native</artifactId>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.graalphp</groupId>
   <artifactId>graalphp-parent</artifactId>
-  <version>20.1.0-SNAPSHOT</version>
+  <version>20.2.0-SNAPSHOT</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <m2e.apt.activation>jdt_apt</m2e.apt.activation>
-    <graalvm.version>20.1.0</graalvm.version>
+    <graalvm.version>20.2.0</graalvm.version>
   </properties>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
A fairly simple search-and-replace, but it seems to work well, including in polyglot usage:

```
$ graalpython --polyglot --jvm --vm.Dtruffle.class.path.append=graalphp-language/target/graalphp.jar 
Python 3.8.2 (Sun Sep 20 13:49:11 CEST 2020)
[Graal, GraalVM CE, Java 11.0.8] on linux
Type "help", "copyright", "credits" or "license" for more information.
Please note: This Python implementation is in the very early stages, and can run little more than basic benchmarks at this point.
>>> import polyglot
>>> polyglot.eval(language='php', string='<?php\n1 + 2;') + 3
6
```

(Where `graalpython` is [graalpython-jdk11-bin](https://aur.archlinux.org/packages/graalpython-jdk11-bin), version 20.2.0.)

`git grep -F 20.1.0` reports one remaining occurrence of the old version number, in `benchmarks/scripts-report/measurements.sqlite`, which I guess should remain as it is.

There are a handful of deprecation warnings in the build output:
```
[WARNING] …/graalphp-parser/org.eclipse.php.core/src/main/java/org/eclipse/php/core/ast/nodes/Program.java: Some input files use or override a deprecated API.
[WARNING] …/graalphp-parser/test/src/test/java/org/graalphp/parser/suite/FileTestSuite.java: …/graalphp-parser/test/src/test/java/org/graalphp/parser/suite/FileTestSuite.java uses or overrides a deprecated API.
[WARNING] …/graalphp-language/src/main/java/org/graalphp/PhpLanguage.java: …/graalphp-language/src/main/java/org/graalphp/PhpLanguage.java uses or overrides a deprecated API.
```